### PR TITLE
Added GetAwaiter extension for UnityEngine.Coroutine objects

### DIFF
--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/IEnumeratorAwaitExtensions.cs
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/IEnumeratorAwaitExtensions.cs
@@ -100,6 +100,14 @@ public static class IEnumeratorAwaitExtensions
             new CoroutineWrapper<object>(coroutine, awaiter).Run()));
         return awaiter;
     }
+    
+    public static SimpleCoroutineAwaiter<object> GetAwaiter(this Coroutine coroutine)
+    {
+        var awaiter = new SimpleCoroutineAwaiter<object>();
+        RunOnUnityScheduler(() => AsyncCoroutineRunner.Instance.StartCoroutine(
+            new CoroutineWrapper<object>(InstructionWrappers.WrapCoroutine(coroutine), awaiter).Run()));
+        return awaiter;
+    }
 
     static SimpleCoroutineAwaiter GetAwaiterReturnVoid(object instruction)
     {
@@ -394,6 +402,11 @@ public static class IEnumeratorAwaitExtensions
         {
             yield return instruction;
             awaiter.Complete(instruction.asset, null);
+        }
+        
+        internal static IEnumerator WrapCoroutine(Coroutine coroutine)
+        {
+            yield return coroutine;
         }
     }
 }


### PR DESCRIPTION
This PR enables awaiting on a coroutine object that has been created previously.

Example:

`
// start a coroutine
Coroutine coroutine = StartCoroutine(MyCoroutine());

// do things while the coroutine is running.
// ...

// now waits for the coroutine to complete.
await coroutine;
`