### PR TITLE
Mark the GetAwaiter for WWW as obsolete

### DIFF
--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/IEnumeratorAwaitExtensions.cs
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/IEnumeratorAwaitExtensions.cs
@@ -64,6 +64,7 @@ public static class IEnumeratorAwaitExtensions
     }
 
     // Return itself so you can do things like (await new WWW(url)).bytes
+    [Obsolete]
     public static SimpleCoroutineAwaiter<WWW> GetAwaiter(this WWW instruction)
     {
         return GetAwaiterReturnSelf(instruction);


### PR DESCRIPTION
Since WWW is Obsolete, using it shows warnings in the editor.
Marking the GetAwaiter as Obsolete as well removes the warnings.