### PR TITLE
Add support for unit-testing async code in the editor

### DIFF
--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/AsyncAwaitUtil.asmdef
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/AsyncAwaitUtil.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "AsyncAwaitUtil",
+    "references": [
+        "GUID:478a2357cc57436488a56e564b08d223"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.editorcoroutines",
+            "expression": "0.0.2-preview",
+            "define": "HAVE_EDITOR_COROUTINES"
+        }
+    ]
+}

--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/AsyncAwaitUtil.asmdef.meta
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/AsyncAwaitUtil.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 77496ac4da31e304f9e7872e863b54e8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/Internal/AsyncCoroutineRunner.cs
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/Internal/AsyncCoroutineRunner.cs
@@ -1,19 +1,49 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
+
 using UnityEngine;
+#if UNITY_EDITOR && HAVE_EDITOR_COROUTINES
+using Unity.EditorCoroutines.Editor;
+#endif
 
 namespace UnityAsyncAwaitUtil
 {
-    public class AsyncCoroutineRunner : MonoBehaviour
+    public class AsyncCoroutineRunner : MonoBehaviour, AsyncCoroutineRunner.ICoroutineRunner
     {
-        static AsyncCoroutineRunner _instance;
+        public interface ICoroutineRunner
+        {
+            object StartCoroutine(IEnumerator routine);
+        }
 
-        public static AsyncCoroutineRunner Instance
+#if UNITY_EDITOR
+        class EditorAsyncCoroutineRunner : ICoroutineRunner
+        {
+            object ICoroutineRunner.StartCoroutine(IEnumerator routine)
+            {
+#if HAVE_EDITOR_COROUTINES
+                return EditorCoroutineUtility.StartCoroutine(routine, this);
+#elif UNITY_2019_1_OR_NEWER
+                throw new NotImplementedException("Install package com.unity.editorcoroutines");
+#else
+                // asmdef "Version Defines" support doesn't exist yet
+                throw new NotImplementedException("Install package com.unity.editorcoroutines and define HAVE_EDITOR_COROUTINES");
+#endif
+            }
+        }
+#endif
+
+        static ICoroutineRunner _instance;
+
+        public static ICoroutineRunner Instance
         {
             get
             {
+#if UNITY_EDITOR
+                if (_instance == null && !Application.isPlaying)
+                {
+                    _instance = new EditorAsyncCoroutineRunner();
+                }
+#endif
                 if (_instance == null)
                 {
                     _instance = new GameObject("AsyncCoroutineRunner")
@@ -30,6 +60,11 @@ namespace UnityAsyncAwaitUtil
             gameObject.hideFlags = HideFlags.HideAndDontSave;
 
             DontDestroyOnLoad(gameObject);
+        }
+
+        object ICoroutineRunner.StartCoroutine(IEnumerator routine)
+        {
+            return StartCoroutine(routine);
         }
     }
 }

--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/Internal/SyncContextUtil.cs
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Source/Internal/SyncContextUtil.cs
@@ -10,6 +10,9 @@ namespace UnityAsyncAwaitUtil
 {
     public static class SyncContextUtil
     {
+#if UNITY_EDITOR
+        [UnityEditor.InitializeOnLoadMethod]
+#endif
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static void Install()
         {

--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Tests/Editor.meta
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 94b93817f8792fd45835bebba406b814
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Tests/Editor/TestMisc.cs
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Tests/Editor/TestMisc.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace UnityAsyncAwaitUtil
+{
+    class TestMisc
+    {
+        [UnityTest]
+        public IEnumerator TestAsyncCoroutineRunnerInEditor()
+        {
+            List<bool> result = new List<bool>();
+            AsyncCoroutineRunner.Instance.StartCoroutine(AppendCoroutine(result));
+            for (int i = 0; i < 10; ++i)
+            {
+                if (result.Count > 0) { yield break; }
+                yield return null;
+            }
+            Assert.Fail("Coroutine did not complete");
+        }
+
+        static IEnumerator AppendCoroutine(List<bool> result)
+        {
+            yield return null;
+            result.Add(true);
+        }
+    }
+}

--- a/UnityProject/Assets/Plugins/AsyncAwaitUtil/Tests/Editor/TestMisc.cs.meta
+++ b/UnityProject/Assets/Plugins/AsyncAwaitUtil/Tests/Editor/TestMisc.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33b332b97e3f8004ab233b5da2bfa109
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This overlaps #18 and addresses #9. This approach differs in that it uses a Unity-provided package for scheduling coroutines at edit time. It also includes worked examples of how to run async unit tests.

It requires that end users install the package com.unity.editorcoroutine. If the end user is using Unity 2018 or below, they must also manually define HAVE_EDITOR_COROUTINES. In Unity 2019 and above, the define is handled automatically by the included .asmdef file.